### PR TITLE
Refactor: Standardize entity property names and relations

### DIFF
--- a/backend/src/database/entities/report-change.entity.ts
+++ b/backend/src/database/entities/report-change.entity.ts
@@ -8,7 +8,7 @@ export class ReportChange {
     @PrimaryGeneratedColumn()
     id: number;
     
-    @ManyToOne(() => User, (user) => user.reports)
+    @ManyToOne(() => User, (user) => user.reportChanges)
     creator: User;
     
     @ManyToOne(() => Report, (report) => report.changes)

--- a/backend/src/database/entities/report.entity.ts
+++ b/backend/src/database/entities/report.entity.ts
@@ -32,16 +32,32 @@ export class Report {
     @Column({ type: "text" })
     description: string;
 
-    @Column({ type: "decimal", precision: 9, scale: 6 })
+    @Column({
+        type: "decimal",
+        precision: 9,
+        scale: 6,
+        transformer: {
+            to: (value: number) => value?.toString(),
+            from: (value: string) => parseFloat(value),
+        },
+    })
     latitude: number;
 
-    @Column({ type: "decimal", precision: 9, scale: 6 })
+    @Column({
+        type: "decimal",
+        precision: 9,
+        scale: 6,
+        transformer: {
+            to: (value: number) => value?.toString(),
+            from: (value: string) => parseFloat(value),
+        },
+    })
     longitude: number;
 
     @Column({ default: true, name: "is_visible" })
     isVisible: boolean;
 
-    @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
+    @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP", name: "created_at" })
     createdAt: Date;
 
     @Column({

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -4,6 +4,7 @@ import { Report } from "./report.entity";
 import { Comment } from "./comment.entity";
 import { Message } from "./message.entity";
 import { Vote } from "./vote.entity";
+import { ReportChange } from "./report-change.entity";
 @Entity("users")
 export class User {
     @PrimaryGeneratedColumn()
@@ -35,6 +36,9 @@ export class User {
 
     @OneToMany(() => Report, (report) => report.creator)
     reports: Report[];
+
+    @OneToMany(() => ReportChange, (reportChange) => reportChange.creator)
+    reportChanges: ReportChange[];
 
     @OneToMany(() => Comment, (comment) => comment.creator)
     comments: Comment[];

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -13,8 +13,8 @@ export class User {
     @Column({ default: true })
     active: boolean;
 
-    @Column({ unique: true})
-    number: string;
+    @Column({ unique: true, name: "phone_number", nullable: false })
+    phoneNumber: string;
     
     @Column()
     password: string;

--- a/init/infracheck_db.sql
+++ b/init/infracheck_db.sql
@@ -159,7 +159,7 @@ CREATE TABLE user_reports_followed (
 
 CREATE TABLE users (
     id integer NOT NULL,
-    number character varying NOT NULL,
+    phone_number character varying NOT NULL,
     password character varying NOT NULL,
     name character varying NOT NULL,
     last_name character varying NOT NULL,


### PR DESCRIPTION
This pull request introduces changes to the database schema and related entity files to improve consistency and functionality. The most important updates include renaming fields for clarity, adding transformers for numeric fields, and enhancing relationships between entities.

### Database Schema Updates:
* Renamed the `number` column to `phone_number` in the `users` table and made it non-nullable for better clarity and consistency. (`[init/infracheck_db.sqlL162-R162](diffhunk://#diff-6c56ed27bd03b67c38207f2368a2d4964ba4d99816c94b8b79b8e87d17f8ea22L162-R162)`)

### Entity Updates:
#### User Entity:
* Renamed the `number` property to `phoneNumber` and updated its configuration to include `name: "phone_number"` and `nullable: false`. (`[backend/src/database/entities/user.entity.tsL15-R17](diffhunk://#diff-809f14d16ed587dd4a373939ef15144e1dd66b13c12befcdf8bb3171b9f697cdL15-R17)`)
* Added a new `reportChanges` relationship to associate users with `ReportChange` entities. (`[backend/src/database/entities/user.entity.tsR40-R42](diffhunk://#diff-809f14d16ed587dd4a373939ef15144e1dd66b13c12befcdf8bb3171b9f697cdR40-R42)`)
* Imported the `ReportChange` entity to support the new relationship. (`[backend/src/database/entities/user.entity.tsR7](diffhunk://#diff-809f14d16ed587dd4a373939ef15144e1dd66b13c12befcdf8bb3171b9f697cdR7)`)

#### Report Entity:
* Added a transformer to the `latitude` and `longitude` fields to handle conversion between `number` and `string` for database compatibility. (`[backend/src/database/entities/report.entity.tsL35-R60](diffhunk://#diff-31e6e22cb67ec5f7e61a30b9ef1f0339e07cf1eda6bd4b7154277857b58466feL35-R60)`)
* Renamed the `createdAt` column to `created_at` for consistency with database naming conventions. (`[backend/src/database/entities/report.entity.tsL35-R60](diffhunk://#diff-31e6e22cb67ec5f7e61a30b9ef1f0339e07cf1eda6bd4b7154277857b58466feL35-R60)`)

#### ReportChange Entity:
* Updated the `creator` relationship to reference the `reportChanges` property in the `User` entity instead of `reports`. (`[backend/src/database/entities/report-change.entity.tsL11-R11](diffhunk://#diff-d2d73addbbcb56e49a254c3ac56be7cbd9b0b279f6b8a3ed6bd977ae99c1c81dL11-R11)`)