### PR TITLE
Add backend unit tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -89,6 +89,9 @@
         },
         "collectCoverageFrom": ["**/*.(t|j)s"],
         "coverageDirectory": "../coverage",
-        "testEnvironment": "node"
+        "testEnvironment": "node",
+        "moduleNameMapper": {
+            "^src/(.*)$": "<rootDir>/$1"
+        }
     }
 }

--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UnauthorizedException, NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { USER_SERVICE } from '../users/interfaces/user-service.interface';
+import { VERIFICATION } from 'src/common/constants/verification.constants';
+import { RefreshToken } from 'src/database/entities/refresh-token.entity';
+import { Role } from 'src/common/enums/roles.enums';
+import type { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+
+describe('AuthService', () => {
+    let service: AuthService;
+    let usersService: any;
+    let jwtService: any;
+    let repo: jest.Mocked<Repository<RefreshToken>>;
+
+    beforeEach(async () => {
+        usersService = {
+            findByPhoneNumberWithPassword: jest.fn(),
+            registerNeighbor: jest.fn(),
+            findByPhoneNumber: jest.fn(),
+            findByIdWithPassword: jest.fn(),
+            update: jest.fn(),
+        };
+        jwtService = {
+            signAsync: jest.fn(),
+            verifyAsync: jest.fn(),
+        };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                AuthService,
+                { provide: USER_SERVICE, useValue: usersService },
+                { provide: getRepositoryToken(RefreshToken), useValue: { findOne: jest.fn(), save: jest.fn(), delete: jest.fn(), create: jest.fn() } },
+                { provide: VERIFICATION.REGISTER_TOKEN, useValue: { sendVerificationCode: jest.fn() } },
+                { provide: VERIFICATION.RECOVER_PASSWORD_TOKEN, useValue: { verifyCode: jest.fn(), sendVerificationCode: jest.fn() } },
+                { provide: JwtService, useValue: jwtService },
+            ],
+        }).compile();
+
+        service = module.get<AuthService>(AuthService);
+        repo = module.get(getRepositoryToken(RefreshToken));
+        process.env.JWT_SECRET = 'secret';
+        process.env.JWT_REFRESH_SECRET = 'refresh';
+    });
+
+    describe('login', () => {
+        it('returns tokens when credentials are valid', async () => {
+            const user = { id: 1, phoneNumber: '+1', password: 'hash', name: 'n', lastName: 'l', role: Role.NEIGHBOR };
+            usersService.findByPhoneNumberWithPassword.mockResolvedValueOnce(user);
+            jest.spyOn(bcrypt as any, 'compare').mockResolvedValueOnce(true as any);
+            jwtService.signAsync.mockResolvedValueOnce('access').mockResolvedValueOnce('refresh');
+            repo.create.mockReturnValue({} as RefreshToken);
+            await expect(service.login({ phoneNumber: '+1', password: 'pass' })).resolves.toEqual({
+                accessToken: 'access',
+                refreshToken: 'refresh',
+                user: {
+                    id: 1,
+                    phoneNumber: '+1',
+                    name: 'n',
+                    lastName: 'l',
+                    role: Role.NEIGHBOR,
+                },
+            });
+        });
+
+        it('throws UnauthorizedException when user not found', async () => {
+            usersService.findByPhoneNumberWithPassword.mockRejectedValueOnce(new NotFoundException());
+            await expect(service.login({ phoneNumber: '+1', password: 'p' })).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('throws UnauthorizedException when password invalid', async () => {
+            const user = { id: 1, phoneNumber: '+1', password: 'hash' };
+            usersService.findByPhoneNumberWithPassword.mockResolvedValueOnce(user);
+            jest.spyOn(bcrypt as any, 'compare').mockResolvedValueOnce(false as any);
+            await expect(service.login({ phoneNumber: '+1', password: 'p' })).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+    });
+
+    describe('getUserIfRefreshTokenMatches', () => {
+        it('returns user when token valid', async () => {
+            const user = { id: 1 } as any;
+            repo.findOne.mockResolvedValueOnce({ token: 't', user, expiresAt: new Date(Date.now() + 1000) } as any);
+            await expect(service.getUserIfRefreshTokenMatches('t', 1)).resolves.toBe(user);
+        });
+
+        it('returns null when token expired', async () => {
+            repo.findOne.mockResolvedValueOnce({ token: 't', user: {}, expiresAt: new Date(Date.now() - 1000) } as any);
+            await expect(service.getUserIfRefreshTokenMatches('t', 1)).resolves.toBeNull();
+        });
+    });
+});

--- a/backend/src/modules/upload/services/upload.service.spec.ts
+++ b/backend/src/modules/upload/services/upload.service.spec.ts
@@ -1,0 +1,31 @@
+import { UploadService } from './upload.service';
+import type { IImageProcessor } from '../image-processing/interfaces/image-processor.interface';
+import type { IImageValidator } from '../image-validation/interfaces/image-validator.interface';
+import type { IStorageService } from '../storage/interfaces/storage-service.interface';
+
+describe('UploadService', () => {
+    let service: UploadService;
+    let processor: jest.Mocked<IImageProcessor>;
+    let validator: jest.Mocked<IImageValidator>;
+    let storage: jest.Mocked<IStorageService>;
+
+    beforeEach(() => {
+        processor = { processImage: jest.fn() } as any;
+        validator = { validate: jest.fn() } as any;
+        storage = { upload: jest.fn() } as any;
+        service = new UploadService(processor, validator, storage);
+    });
+
+    it('processes, validates and uploads the file', async () => {
+        const file = { buffer: Buffer.from('buf'), originalname: 'pic.png' } as any;
+        const processed = Buffer.from('processed');
+        processor.processImage.mockResolvedValueOnce(processed);
+        validator.validate.mockResolvedValueOnce();
+        storage.upload.mockResolvedValueOnce('url');
+
+        await expect(service.uploadFile(file)).resolves.toBe('url');
+        expect(processor.processImage).toHaveBeenCalledWith(file.buffer);
+        expect(validator.validate).toHaveBeenCalledWith(processed);
+        expect(storage.upload).toHaveBeenCalledWith(processed, expect.stringMatching(/pic.png$/));
+    });
+});

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { User } from 'src/database/entities/user.entity';
+import { Role } from 'src/common/enums/roles.enums';
+import { UserStatus } from 'src/common/enums/user-status.enums';
+import type { Repository } from 'typeorm';
+
+describe('UsersService', () => {
+    let service: UsersService;
+    let repo: jest.Mocked<Repository<User>>;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                UsersService,
+                {
+                    provide: getRepositoryToken(User),
+                    useValue: {
+                        find: jest.fn(),
+                        findOne: jest.fn(),
+                        create: jest.fn(),
+                        save: jest.fn(),
+                        delete: jest.fn(),
+                        update: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<UsersService>(UsersService);
+        repo = module.get(getRepositoryToken(User));
+    });
+
+    describe('findById', () => {
+        it('returns a user when found', async () => {
+            const user = {
+                id: 1,
+                phoneNumber: '+56911111111',
+                name: 'Test',
+                lastName: 'User',
+                role: Role.NEIGHBOR,
+                status: UserStatus.ACTIVE,
+                createdAt: new Date(),
+                passwordUpdatedAt: null,
+            } as User;
+            repo.findOne.mockResolvedValueOnce(user);
+            await expect(service.findById(1)).resolves.toEqual(user);
+        });
+
+        it('throws NotFoundException when not found', async () => {
+            repo.findOne.mockResolvedValueOnce(null);
+            await expect(service.findById(1)).rejects.toBeInstanceOf(NotFoundException);
+        });
+    });
+
+    describe('registerNeighbor', () => {
+        const dto = {
+            phoneNumber: '+56922222222',
+            password: 'pass',
+            name: 'Jane',
+            lastName: 'Doe',
+        };
+
+        it('creates a new user', async () => {
+            repo.findOne.mockResolvedValueOnce(null);
+            const created = { id: 2, ...dto } as User;
+            repo.create.mockReturnValueOnce(created);
+            repo.save.mockResolvedValueOnce(created);
+            jest.spyOn(service, 'findById').mockResolvedValueOnce(created as any);
+
+            await expect(service.registerNeighbor(dto)).resolves.toEqual(created);
+            expect(repo.create).toHaveBeenCalledWith(dto);
+            expect(repo.save).toHaveBeenCalledWith(created);
+        });
+
+        it('throws ConflictException when phone already exists', async () => {
+            repo.findOne.mockResolvedValueOnce({} as User);
+            await expect(service.registerNeighbor(dto)).rejects.toBeInstanceOf(ConflictException);
+        });
+    });
+
+    describe('remove', () => {
+        it('removes a user when deletion affected rows > 0', async () => {
+            repo.delete.mockResolvedValueOnce({ affected: 1 } as any);
+            await expect(service.remove(1)).resolves.toBeUndefined();
+        });
+
+        it('throws NotFoundException when delete affected 0 rows', async () => {
+            repo.delete.mockResolvedValueOnce({ affected: 0 } as any);
+            await expect(service.remove(1)).rejects.toBeInstanceOf(NotFoundException);
+        });
+    });
+});

--- a/backend/src/modules/verification/twilio-verification.service.spec.ts
+++ b/backend/src/modules/verification/twilio-verification.service.spec.ts
@@ -1,0 +1,56 @@
+import { BadRequestException } from '@nestjs/common';
+import { TwilioVerificationService } from './twilio-verification.service';
+import type { ConfigService } from '@nestjs/config';
+
+const mockTwilioClient = {
+    verify: {
+        v2: {
+            services: jest.fn().mockReturnThis(),
+            verifications: { create: jest.fn() },
+            verificationChecks: { create: jest.fn() },
+        },
+    },
+};
+
+jest.mock('twilio', () => ({ Twilio: jest.fn(() => mockTwilioClient) }));
+
+describe('TwilioVerificationService', () => {
+    let service: TwilioVerificationService;
+    let twilioClient: typeof mockTwilioClient;
+    const configService = { get: jest.fn().mockReturnValue('x') } as unknown as ConfigService;
+
+    beforeEach(() => {
+        service = new TwilioVerificationService(configService, 'service-sid');
+        twilioClient = mockTwilioClient;
+        (service as any).twilioClient = twilioClient;
+        (service as any).serviceSid = 'service-sid';
+    });
+
+    describe('sendVerificationCode', () => {
+        it('resolves when Twilio returns pending', async () => {
+            twilioClient.verify.v2.verifications.create.mockResolvedValueOnce({ status: 'pending' });
+            await expect(service.sendVerificationCode('+123')).resolves.toBeUndefined();
+            expect(twilioClient.verify.v2.services).toHaveBeenCalledWith('service-sid');
+            expect(twilioClient.verify.v2.verifications.create).toHaveBeenCalledWith({ to: '+123', channel: 'sms' });
+        });
+
+        it('throws when status is not pending', async () => {
+            twilioClient.verify.v2.verifications.create.mockResolvedValueOnce({ status: 'failed' });
+            await expect(service.sendVerificationCode('+123')).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+
+    describe('verifyCode', () => {
+        it('resolves when Twilio approves the code', async () => {
+            twilioClient.verify.v2.verificationChecks.create.mockResolvedValueOnce({ status: 'approved' });
+            await expect(service.verifyCode('+123', '456')).resolves.toBeUndefined();
+            expect(twilioClient.verify.v2.services).toHaveBeenCalledWith('service-sid');
+            expect(twilioClient.verify.v2.verificationChecks.create).toHaveBeenCalledWith({ to: '+123', code: '456' });
+        });
+
+        it('throws when verification fails', async () => {
+            twilioClient.verify.v2.verificationChecks.create.mockResolvedValueOnce({ status: 'pending' });
+            await expect(service.verifyCode('+123', '456')).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,21 +1,24 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "declaration": true,
-    "removeComments": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "ES2023",
-    "sourceMap": true,
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "incremental": true,
-    "skipLibCheck": true,
-    "strictNullChecks": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
-  }
+    "compilerOptions": {
+        "module": "commonjs",
+        "declaration": true,
+        "removeComments": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "allowSyntheticDefaultImports": true,
+        "target": "ES2023",
+        "sourceMap": true,
+        "outDir": "./dist",
+        "baseUrl": "./",
+        "paths": {
+            "src/*": ["src/*"]
+        },
+        "incremental": true,
+        "skipLibCheck": true,
+        "strictNullChecks": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitAny": false,
+        "strictBindCallApply": false,
+        "noFallthroughCasesInSwitch": false
+    }
 }


### PR DESCRIPTION
## Summary
- add Jest tests for AuthService
- cover UploadService behavior with mocks
- verify TwilioVerificationService logic with mocked Twilio client

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68409de995a883308216df5c8d993591