### PR TITLE
feat: implement follow management between users and reports

### DIFF
--- a/backend/src/modules/reports/follows/controllers/follows.controller.ts
+++ b/backend/src/modules/reports/follows/controllers/follows.controller.ts
@@ -1,0 +1,124 @@
+import { Controller, Delete, Get, Inject, Param, ParseIntPipe, Post, Req } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+    FollowActionResponseDto,
+    FollowStatusResponseDto,
+    ReportFollowersIdsResponseDto,
+    ReportFollowersResponseDto,
+} from '../dto';
+import { FOLLOWS_SERVICE, IFollowsService } from '../interfaces/follows-service.interface';
+
+/**
+ * Controller for managing report follow actions.
+ *
+ * Provides endpoints to follow/unfollow reports, retrieve followers, and check follow status.
+ *
+ * @module FollowsController
+ * @tag Report Follows
+ *
+ * Endpoints:
+ * - POST /reports/:reportId/follow: Follow a report.
+ * - DELETE /reports/:reportId/unfollow: Unfollow a report.
+ * - GET /reports/:reportId/followers: Get names of report followers.
+ * - GET /reports/:reportId/followers-ids: Get IDs of report followers.
+ * - GET /reports/:reportId/follow-status: Check if the current user is following the report.
+ *
+ * @param {number} reportId - ID of the report to perform actions on.
+ * @param {Request} req - Express request object, containing authenticated user info.
+ *
+ * @injects IFollowsService - Service for handling follow logic.
+ */
+@ApiTags('Report Follows')
+@Controller({
+    path: 'reports/:reportId',
+    version: '1',
+})
+export class FollowsController {
+    constructor(
+        @Inject(FOLLOWS_SERVICE)
+        private readonly followsService: IFollowsService,
+    ) {}
+
+    @Post('follow')
+    @ApiOperation({ summary: 'Follow a report' })
+    @ApiParam({ name: 'reportId', description: 'ID of the report to follow', type: 'number' })
+    @ApiResponse({
+        status: 201,
+        description: 'Report followed successfully',
+        type: FollowActionResponseDto,
+    })
+    @ApiResponse({ status: 400, description: 'Invalid request parameters' })
+    @ApiResponse({ status: 404, description: 'User or report not found' })
+    @ApiResponse({ status: 409, description: 'User is already following this report' })
+    async followReport(
+        @Param('reportId', ParseIntPipe) reportId: number,
+        @Req() req,
+    ): Promise<FollowActionResponseDto> {
+        const userId = req.user.id;
+        return await this.followsService.followReport(userId, reportId);
+    }
+
+    @Delete('unfollow')
+    @ApiOperation({ summary: 'Unfollow a report' })
+    @ApiParam({ name: 'reportId', description: 'ID of the report to unfollow', type: 'number' })
+    @ApiResponse({
+        status: 200,
+        description: 'Report unfollowed successfully',
+        type: FollowActionResponseDto,
+    })
+    @ApiResponse({ status: 400, description: 'Invalid request parameters' })
+    @ApiResponse({ status: 404, description: 'User or report not found' })
+    @ApiResponse({ status: 409, description: 'User is not following this report' })
+    async unfollowReport(
+        @Param('reportId', ParseIntPipe) reportId: number,
+        @Req() req,
+    ): Promise<FollowActionResponseDto> {
+        const userId = req.user.id;
+        return await this.followsService.unfollowReport(userId, reportId);
+    }
+
+    @Get('followers')
+    @ApiOperation({ summary: 'Get report followers names' })
+    @ApiParam({ name: 'reportId', description: 'ID of the report', type: 'number' })
+    @ApiResponse({
+        status: 200,
+        description: 'List of follower names',
+        type: ReportFollowersResponseDto,
+    })
+    @ApiResponse({ status: 400, description: 'Invalid request parameters' })
+    @ApiResponse({ status: 404, description: 'Report not found' })
+    async getReportFollowers(
+        @Param('reportId', ParseIntPipe) reportId: number,
+    ): Promise<ReportFollowersResponseDto> {
+        return await this.followsService.getReportFollowers(reportId);
+    }
+
+    @Get('followers-ids')
+    @ApiOperation({ summary: 'Get report followers IDs' })
+    @ApiParam({ name: 'reportId', description: 'ID of the report', type: 'number' })
+    @ApiResponse({
+        status: 200,
+        description: 'List of follower IDs',
+        type: ReportFollowersIdsResponseDto,
+    })
+    @ApiResponse({ status: 400, description: 'Invalid request parameters' })
+    @ApiResponse({ status: 404, description: 'Report not found' })
+    async getReportFollowersIds(
+        @Param('reportId', ParseIntPipe) reportId: number,
+    ): Promise<ReportFollowersIdsResponseDto> {
+        return await this.followsService.getFollowersIds(reportId);
+    }
+
+    @Get('follow-status')
+    @ApiOperation({ summary: 'Check if user is following the report' })
+    @ApiParam({ name: 'reportId', description: 'ID of the report', type: 'number' })
+    @ApiResponse({ status: 200, description: 'Follow status', type: FollowStatusResponseDto })
+    @ApiResponse({ status: 400, description: 'Invalid request parameters' })
+    async getFollowStatus(
+        @Param('reportId', ParseIntPipe) reportId: number,
+        @Req() req,
+    ): Promise<FollowStatusResponseDto> {
+        const userId = req.user.id;
+        return await this.followsService.isFollowingReport(userId, reportId);
+    }
+}

--- a/backend/src/modules/reports/follows/dto/follow-action-response.dto.ts
+++ b/backend/src/modules/reports/follows/dto/follow-action-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FollowActionResponseDto {
+    @ApiProperty({
+        description: 'Message indicating the result of the follow/unfollow action',
+        example: 'Report followed successfully',
+    })
+    message: string;
+}

--- a/backend/src/modules/reports/follows/dto/follow-status-response.dto.ts
+++ b/backend/src/modules/reports/follows/dto/follow-status-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FollowStatusResponseDto {
+    @ApiProperty({
+        description: 'Indicates whether the user is following the report',
+        example: true,
+    })
+    isFollowing: boolean;
+}

--- a/backend/src/modules/reports/follows/dto/index.ts
+++ b/backend/src/modules/reports/follows/dto/index.ts
@@ -1,0 +1,6 @@
+// Response DTOs
+export { FollowActionResponseDto } from './follow-action-response.dto';
+export { FollowStatusResponseDto } from './follow-status-response.dto';
+export { ReportFollowersResponseDto } from './report-followers-response.dto';
+export { ReportFollowersIdsResponseDto } from './report-followers-ids-response.dto';
+export { UserFollowedReportsResponseDto } from './user-followed-reports-response.dto';

--- a/backend/src/modules/reports/follows/dto/report-followers-ids-response.dto.ts
+++ b/backend/src/modules/reports/follows/dto/report-followers-ids-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReportFollowersIdsResponseDto {
+    @ApiProperty({
+        description: 'List of follower user IDs',
+        example: [1, 15, 23, 42],
+        type: [Number],
+    })
+    followers: number[];
+}

--- a/backend/src/modules/reports/follows/dto/report-followers-response.dto.ts
+++ b/backend/src/modules/reports/follows/dto/report-followers-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReportFollowersResponseDto {
+    @ApiProperty({
+        description: 'List of follower names',
+        example: ['Juan Pérez', 'María González', 'Carlos Rodríguez'],
+        type: [String],
+    })
+    followers: string[];
+}

--- a/backend/src/modules/reports/follows/dto/user-followed-reports-response.dto.ts
+++ b/backend/src/modules/reports/follows/dto/user-followed-reports-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserFollowedReportsResponseDto {
+    @ApiProperty({
+        description: 'List of report IDs that the user is following',
+        example: [5, 12, 18, 25],
+        type: [Number],
+    })
+    reports: number[];
+
+    @ApiProperty({
+        description: 'Total number of reports the user is following',
+        example: 4,
+    })
+    total: number;
+}

--- a/backend/src/modules/reports/follows/follows.module.ts
+++ b/backend/src/modules/reports/follows/follows.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Report } from 'src/database/entities/report.entity';
+import { User } from 'src/database/entities/user.entity';
+import { FollowsController } from './controllers/follows.controller';
+import { FOLLOWS_SERVICE } from './interfaces/follows-service.interface';
+import { FollowsService } from './services/follows.service';
+
+/**
+ * The FollowsModule is a NestJS module responsible for managing the follows feature.
+ *
+ * @module FollowsModule
+ *
+ * @description
+ * - Imports the TypeOrmModule with the User and Report entities for database interaction.
+ * - Registers the FollowsController to handle HTTP requests related to follows.
+ * - Provides the FollowsService using the FOLLOWS_SERVICE token for dependency injection.
+ * - Exports the FOLLOWS_SERVICE token for use in other modules.
+ */
+@Module({
+    imports: [TypeOrmModule.forFeature([User, Report])],
+    controllers: [FollowsController],
+    providers: [
+        {
+            provide: FOLLOWS_SERVICE,
+            useClass: FollowsService,
+        },
+    ],
+    exports: [FOLLOWS_SERVICE],
+})
+export class FollowsModule {}

--- a/backend/src/modules/reports/follows/interfaces/follows-service.interface.ts
+++ b/backend/src/modules/reports/follows/interfaces/follows-service.interface.ts
@@ -1,0 +1,59 @@
+import {
+    FollowActionResponseDto,
+    FollowStatusResponseDto,
+    ReportFollowersIdsResponseDto,
+    ReportFollowersResponseDto,
+    UserFollowedReportsResponseDto,
+} from '../dto';
+
+export const FOLLOWS_SERVICE = 'FOLLOWS_SERVICE';
+
+/**
+ * Interface for managing follow relationships between users and reports.
+ */
+export interface IFollowsService {
+    /**
+     * Allows a user to follow a specific report.
+     * @param userId - The ID of the user who wants to follow the report.
+     * @param reportId - The ID of the report to be followed.
+     * @returns A promise that resolves to the result of the follow action.
+     */
+    followReport(userId: number, reportId: number): Promise<FollowActionResponseDto>;
+
+    /**
+     * Allows a user to unfollow a specific report.
+     * @param userId - The ID of the user who wants to unfollow the report.
+     * @param reportId - The ID of the report to be unfollowed.
+     * @returns A promise that resolves to the result of the unfollow action.
+     */
+    unfollowReport(userId: number, reportId: number): Promise<FollowActionResponseDto>;
+
+    /**
+     * Checks if a user is currently following a specific report.
+     * @param userId - The ID of the user.
+     * @param reportId - The ID of the report.
+     * @returns A promise that resolves to the follow status.
+     */
+    isFollowingReport(userId: number, reportId: number): Promise<FollowStatusResponseDto>;
+
+    /**
+     * Retrieves the list of followers for a specific report.
+     * @param reportId - The ID of the report.
+     * @returns A promise that resolves to the list of report followers.
+     */
+    getReportFollowers(reportId: number): Promise<ReportFollowersResponseDto>;
+
+    /**
+     * Retrieves the list of reports followed by a specific user.
+     * @param userId - The ID of the user.
+     * @returns A promise that resolves to the list of reports followed by the user.
+     */
+    getUserFollowedReports(userId: number): Promise<UserFollowedReportsResponseDto>;
+
+    /**
+     * Retrieves the IDs of all users following a specific report.
+     * @param reportId - The ID of the report.
+     * @returns A promise that resolves to the list of follower IDs.
+     */
+    getFollowersIds(reportId: number): Promise<ReportFollowersIdsResponseDto>;
+}

--- a/backend/src/modules/reports/follows/services/follows.service.spec.ts
+++ b/backend/src/modules/reports/follows/services/follows.service.spec.ts
@@ -1,0 +1,340 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Report } from 'src/database/entities/report.entity';
+import { User } from 'src/database/entities/user.entity';
+import { Repository } from 'typeorm';
+import { FollowsService } from './follows.service';
+
+describe('FollowsService', () => {
+    let service: FollowsService;
+    let userRepository: jest.Mocked<Repository<User>>;
+    let reportRepository: jest.Mocked<Repository<Report>>;
+
+    const mockUser = {
+        id: 1,
+        name: 'John',
+        lastName: 'Doe',
+    } as unknown as User;
+
+    const mockReport = {
+        id: 1,
+        title: 'Test Report',
+        description: 'Test Description',
+        followers: [],
+    } as unknown as Report;
+
+    const mockQueryBuilder = {
+        relation: jest.fn().mockReturnThis(),
+        of: jest.fn().mockReturnThis(),
+        add: jest.fn().mockResolvedValue(undefined),
+        remove: jest.fn().mockResolvedValue(undefined),
+        createQueryBuilder: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getCount: jest.fn(),
+        getOne: jest.fn(),
+        getManyAndCount: jest.fn(),
+    };
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FollowsService,
+                {
+                    provide: getRepositoryToken(User),
+                    useValue: {
+                        findOne: jest.fn(),
+                        createQueryBuilder: jest.fn(() => mockQueryBuilder),
+                    },
+                },
+                {
+                    provide: getRepositoryToken(Report),
+                    useValue: {
+                        findOne: jest.fn(),
+                        createQueryBuilder: jest.fn(() => mockQueryBuilder),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<FollowsService>(FollowsService);
+        userRepository = module.get(getRepositoryToken(User));
+        reportRepository = module.get(getRepositoryToken(Report));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('followReport', () => {
+        beforeEach(() => {
+            userRepository.findOne.mockResolvedValue(mockUser);
+            reportRepository.findOne.mockResolvedValue(mockReport);
+        });
+
+        it('should successfully follow a report', async () => {
+            mockQueryBuilder.getCount.mockResolvedValue(0); // Not following
+            mockQueryBuilder.add.mockResolvedValue(undefined);
+
+            const result = await service.followReport(1, 1);
+
+            expect(result).toEqual({ message: 'Report followed successfully' });
+            expect(reportRepository.createQueryBuilder).toHaveBeenCalled();
+            expect(mockQueryBuilder.relation).toHaveBeenCalledWith(Report, 'followers');
+            expect(mockQueryBuilder.of).toHaveBeenCalledWith(1);
+            expect(mockQueryBuilder.add).toHaveBeenCalledWith(1);
+        });
+
+        it('should throw ConflictException when user is already following', async () => {
+            mockQueryBuilder.getCount.mockResolvedValue(1); // Already following
+
+            await expect(service.followReport(1, 1)).rejects.toThrow(
+                new ConflictException('User is already following this report'),
+            );
+        });
+
+        it('should throw NotFoundException when user does not exist', async () => {
+            userRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.followReport(1, 1)).rejects.toThrow(NotFoundException);
+        });
+
+        it('should throw NotFoundException when report does not exist', async () => {
+            reportRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.followReport(1, 1)).rejects.toThrow(NotFoundException);
+        });
+
+        it('should throw BadRequestException when userId is invalid', async () => {
+            await expect(service.followReport(0, 1)).rejects.toThrow(BadRequestException);
+        });
+
+        it('should throw BadRequestException when reportId is invalid', async () => {
+            await expect(service.followReport(1, 0)).rejects.toThrow(BadRequestException);
+        });
+    });
+
+    describe('unfollowReport', () => {
+        beforeEach(() => {
+            userRepository.findOne.mockResolvedValue(mockUser);
+            reportRepository.findOne.mockResolvedValue(mockReport);
+        });
+
+        it('should successfully unfollow a report', async () => {
+            mockQueryBuilder.getCount.mockResolvedValue(1); // Is following
+            mockQueryBuilder.remove.mockResolvedValue(undefined);
+
+            const result = await service.unfollowReport(1, 1);
+
+            expect(result).toEqual({ message: 'Report unfollowed successfully' });
+            expect(reportRepository.createQueryBuilder).toHaveBeenCalled();
+            expect(mockQueryBuilder.relation).toHaveBeenCalledWith(Report, 'followers');
+            expect(mockQueryBuilder.of).toHaveBeenCalledWith(1);
+            expect(mockQueryBuilder.remove).toHaveBeenCalledWith(1);
+        });
+
+        it('should throw ConflictException when user is not following', async () => {
+            mockQueryBuilder.getCount.mockResolvedValue(0); // Not following
+
+            await expect(service.unfollowReport(1, 1)).rejects.toThrow(
+                new ConflictException('User is not following this report'),
+            );
+        });
+
+        it('should throw NotFoundException when user does not exist', async () => {
+            userRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.unfollowReport(1, 1)).rejects.toThrow(NotFoundException);
+        });
+
+        it('should throw NotFoundException when report does not exist', async () => {
+            reportRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.unfollowReport(1, 1)).rejects.toThrow(NotFoundException);
+        });
+    });
+
+    describe('isFollowingReport', () => {
+        it('should return true when user is following the report', async () => {
+            mockQueryBuilder.getCount.mockResolvedValue(1);
+
+            const result = await service.isFollowingReport(1, 1);
+
+            expect(result).toEqual({ isFollowing: true });
+            expect(reportRepository.createQueryBuilder).toHaveBeenCalledWith('report');
+            expect(mockQueryBuilder.innerJoin).toHaveBeenCalledWith(
+                'report.followers',
+                'follower',
+                'follower.id = :userId',
+                { userId: 1 },
+            );
+            expect(mockQueryBuilder.where).toHaveBeenCalledWith('report.id = :reportId', {
+                reportId: 1,
+            });
+            expect(mockQueryBuilder.getCount).toHaveBeenCalled();
+        });
+
+        it('should return false when user is not following the report', async () => {
+            mockQueryBuilder.getCount.mockResolvedValue(0);
+
+            const result = await service.isFollowingReport(1, 1);
+
+            expect(result).toEqual({ isFollowing: false });
+        });
+
+        it('should throw BadRequestException when userId is falsy', async () => {
+            await expect(service.isFollowingReport(0, 1)).rejects.toThrow(
+                new BadRequestException('User ID and Report ID are required'),
+            );
+        });
+
+        it('should throw BadRequestException when reportId is falsy', async () => {
+            await expect(service.isFollowingReport(1, 0)).rejects.toThrow(
+                new BadRequestException('User ID and Report ID are required'),
+            );
+        });
+    });
+
+    describe('getReportFollowers', () => {
+        const mockReportWithFollowers = {
+            ...mockReport,
+            followers: [
+                { id: 1, name: 'John' },
+                { id: 2, name: 'Jane' },
+            ],
+        };
+
+        it('should return list of follower names', async () => {
+            reportRepository.findOne.mockResolvedValue(mockReport);
+            mockQueryBuilder.getOne.mockResolvedValue(mockReportWithFollowers);
+
+            const result = await service.getReportFollowers(1);
+
+            expect(result).toEqual({ followers: ['John', 'Jane'] });
+            expect(reportRepository.createQueryBuilder).toHaveBeenCalledWith('report');
+            expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+                'report.followers',
+                'follower',
+            );
+            expect(mockQueryBuilder.where).toHaveBeenCalledWith('report.id = :reportId', {
+                reportId: 1,
+            });
+            expect(mockQueryBuilder.getOne).toHaveBeenCalled();
+        });
+
+        it('should return empty array when report has no followers', async () => {
+            reportRepository.findOne.mockResolvedValue(mockReport);
+            mockQueryBuilder.getOne.mockResolvedValue({ ...mockReport, followers: [] });
+
+            const result = await service.getReportFollowers(1);
+
+            expect(result).toEqual({ followers: [] });
+        });
+
+        it('should return empty array when report is null', async () => {
+            reportRepository.findOne.mockResolvedValue(mockReport);
+            mockQueryBuilder.getOne.mockResolvedValue(null);
+
+            const result = await service.getReportFollowers(1);
+
+            expect(result).toEqual({ followers: [] });
+        });
+
+        it('should throw NotFoundException when report does not exist', async () => {
+            reportRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.getReportFollowers(1)).rejects.toThrow(NotFoundException);
+        });
+    });
+
+    describe('getUserFollowedReports', () => {
+        it('should return list of followed report IDs and total count', async () => {
+            userRepository.findOne.mockResolvedValue(mockUser);
+            const mockReports = [{ id: 1 }, { id: 2 }, { id: 3 }];
+            mockQueryBuilder.getManyAndCount.mockResolvedValue([mockReports, 3]);
+
+            const result = await service.getUserFollowedReports(1);
+
+            expect(result).toEqual({ reports: [1, 2, 3], total: 3 });
+            expect(reportRepository.createQueryBuilder).toHaveBeenCalledWith('report');
+            expect(mockQueryBuilder.innerJoin).toHaveBeenCalledWith(
+                'report.followers',
+                'follower',
+                'follower.id = :userId',
+                { userId: 1 },
+            );
+            expect(mockQueryBuilder.select).toHaveBeenCalledWith(['report.id']);
+            expect(mockQueryBuilder.getManyAndCount).toHaveBeenCalled();
+        });
+
+        it('should return empty array when user follows no reports', async () => {
+            userRepository.findOne.mockResolvedValue(mockUser);
+            mockQueryBuilder.getManyAndCount.mockResolvedValue([[], 0]);
+
+            const result = await service.getUserFollowedReports(1);
+
+            expect(result).toEqual({ reports: [], total: 0 });
+        });
+
+        it('should throw NotFoundException when user does not exist', async () => {
+            userRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.getUserFollowedReports(1)).rejects.toThrow(NotFoundException);
+        });
+    });
+
+    describe('getFollowersIds', () => {
+        const mockReportWithFollowers = {
+            ...mockReport,
+            followers: [
+                { id: 1, name: 'John' },
+                { id: 2, name: 'Jane' },
+            ],
+        };
+
+        it('should return list of follower IDs', async () => {
+            reportRepository.findOne.mockResolvedValue(mockReport);
+            mockQueryBuilder.getOne.mockResolvedValue(mockReportWithFollowers);
+
+            const result = await service.getFollowersIds(1);
+
+            expect(result).toEqual({ followers: [1, 2] });
+            expect(reportRepository.createQueryBuilder).toHaveBeenCalledWith('report');
+            expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+                'report.followers',
+                'follower',
+            );
+            expect(mockQueryBuilder.where).toHaveBeenCalledWith('report.id = :reportId', {
+                reportId: 1,
+            });
+            expect(mockQueryBuilder.getOne).toHaveBeenCalled();
+        });
+
+        it('should return empty array when report has no followers', async () => {
+            reportRepository.findOne.mockResolvedValue(mockReport);
+            mockQueryBuilder.getOne.mockResolvedValue({ ...mockReport, followers: [] });
+
+            const result = await service.getFollowersIds(1);
+
+            expect(result).toEqual({ followers: [] });
+        });
+
+        it('should return empty array when report is null', async () => {
+            reportRepository.findOne.mockResolvedValue(mockReport);
+            mockQueryBuilder.getOne.mockResolvedValue(null);
+
+            const result = await service.getFollowersIds(1);
+
+            expect(result).toEqual({ followers: [] });
+        });
+
+        it('should throw NotFoundException when report does not exist', async () => {
+            reportRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.getFollowersIds(1)).rejects.toThrow(NotFoundException);
+        });
+    });
+});

--- a/backend/src/modules/reports/follows/services/follows.service.ts
+++ b/backend/src/modules/reports/follows/services/follows.service.ts
@@ -2,6 +2,7 @@ import {
     BadRequestException,
     ConflictException,
     Injectable,
+    Logger,
     NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -33,6 +34,7 @@ import { IFollowsService } from '../interfaces/follows-service.interface';
  */
 @Injectable()
 export class FollowsService implements IFollowsService {
+    private readonly logger = new Logger(FollowsService.name);
     constructor(
         @InjectRepository(User)
         private readonly userRepository: Repository<User>,
@@ -159,7 +161,7 @@ export class FollowsService implements IFollowsService {
                 .getOne();
 
             return {
-                followers: report?.followers.map(follower => follower.name) || [],
+                followers: report?.followers.map(follower => follower.name) ?? [],
             };
         } catch (error) {
             this.handleError(error, 'Failed to get report followers');
@@ -210,7 +212,7 @@ export class FollowsService implements IFollowsService {
                 .getOne();
 
             return {
-                followers: report?.followers.map(follower => follower.id) || [],
+                followers: report?.followers.map(follower => follower.id) ?? [],
             };
         } catch (error) {
             this.handleError(error, 'Failed to get followers IDs');
@@ -293,8 +295,13 @@ export class FollowsService implements IFollowsService {
             error instanceof ConflictException ||
             error instanceof BadRequestException
         ) {
+            this.logger.error(`Handled error: ${error.message}`, error.stack);
             throw error;
         }
+        this.logger.error(
+            `Unhandled error: ${defaultMessage}`,
+            error instanceof Error ? error.stack : undefined,
+        );
         throw new BadRequestException(defaultMessage);
     }
 }

--- a/backend/src/modules/reports/follows/services/follows.service.ts
+++ b/backend/src/modules/reports/follows/services/follows.service.ts
@@ -1,0 +1,300 @@
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from 'src/database/entities/report.entity';
+import { User } from 'src/database/entities/user.entity';
+import { Equal, Repository } from 'typeorm';
+import {
+    FollowActionResponseDto,
+    FollowStatusResponseDto,
+    ReportFollowersIdsResponseDto,
+    ReportFollowersResponseDto,
+    UserFollowedReportsResponseDto,
+} from '../dto';
+import { IFollowsService } from '../interfaces/follows-service.interface';
+
+/**
+ * Service for managing user follow actions on reports.
+ *
+ * Provides methods to follow and unfollow reports, check follow status,
+ * retrieve followers of a report, and get reports followed by a user.
+ * Handles validation and error management for follow-related operations.
+ *
+ * @remarks
+ * This service uses TypeORM repositories for `User` and `Report` entities,
+ * and assumes a many-to-many relationship between users and reports via a
+ * `followers` relation on the `Report` entity.
+ *
+ * @implements {IFollowsService}
+ */
+@Injectable()
+export class FollowsService implements IFollowsService {
+    constructor(
+        @InjectRepository(User)
+        private readonly userRepository: Repository<User>,
+        @InjectRepository(Report)
+        private readonly reportRepository: Repository<Report>,
+    ) {}
+
+    /**
+     * Allows a user to follow a specific report.
+     *
+     * This method first validates the existence of the user and the report.
+     * It then checks if the user is already following the report. If so, it throws a
+     * `ConflictException`. Otherwise, it adds the user as a follower of the report.
+     *
+     * @param userId - The ID of the user who wants to follow the report.
+     * @param reportId - The ID of the report to be followed.
+     * @returns A promise that resolves to a `FollowActionResponseDto` containing a success message.
+     * @throws {ConflictException} If the user is already following the report.
+     * @throws {NotFoundException} If the user or report does not exist.
+     * @throws {InternalServerErrorException} For other unexpected errors.
+     */
+    async followReport(userId: number, reportId: number): Promise<FollowActionResponseDto> {
+        try {
+            await this.validateUserAndReport(userId, reportId);
+
+            // Verificar si ya está siguiendo el reporte
+            const isAlreadyFollowing = await this.isFollowingReport(userId, reportId);
+            if (isAlreadyFollowing.isFollowing) {
+                throw new ConflictException('User is already following this report');
+            }
+
+            // Seguir el reporte
+            await this.reportRepository
+                .createQueryBuilder()
+                .relation(Report, 'followers')
+                .of(reportId)
+                .add(userId);
+
+            return { message: 'Report followed successfully' };
+        } catch (error) {
+            this.handleError(error, 'Failed to follow report');
+        }
+    }
+
+    /**
+     * Unfollows a report for a given user.
+     *
+     * Validates the user and report, checks if the user is currently following the report,
+     * and removes the follow relationship if present. Throws a ConflictException if the user
+     * is not following the report. Handles errors and returns a response message upon success.
+     *
+     * @param userId - The ID of the user who wants to unfollow the report.
+     * @param reportId - The ID of the report to unfollow.
+     * @returns A promise that resolves to a FollowActionResponseDto containing a success message.
+     * @throws {ConflictException} If the user is not following the report.
+     * @throws {Error} If an error occurs during the operation.
+     */
+    async unfollowReport(userId: number, reportId: number): Promise<FollowActionResponseDto> {
+        try {
+            await this.validateUserAndReport(userId, reportId);
+
+            // Verificar si está siguiendo el reporte
+            const isFollowing = await this.isFollowingReport(userId, reportId);
+            if (!isFollowing.isFollowing) {
+                throw new ConflictException('User is not following this report');
+            }
+
+            // Dejar de seguir el reporte
+            await this.reportRepository
+                .createQueryBuilder()
+                .relation(Report, 'followers')
+                .of(reportId)
+                .remove(userId);
+
+            return { message: 'Report unfollowed successfully' };
+        } catch (error) {
+            this.handleError(error, 'Failed to unfollow report');
+        }
+    }
+
+    /**
+     * Checks if a user is following a specific report.
+     *
+     * @param userId - The ID of the user to check.
+     * @param reportId - The ID of the report to check.
+     * @returns A promise that resolves to a {@link FollowStatusResponseDto} indicating whether the user is following the report.
+     * @throws {BadRequestException} If either userId or reportId is missing or invalid.
+     * @throws {InternalServerErrorException} If an error occurs during the database query.
+     */
+    async isFollowingReport(userId: number, reportId: number): Promise<FollowStatusResponseDto> {
+        try {
+            // Solo validar que los parámetros no sean nulos/undefined
+            if (!userId || !reportId) {
+                throw new BadRequestException('User ID and Report ID are required');
+            }
+
+            const count = await this.reportRepository
+                .createQueryBuilder('report')
+                .innerJoin('report.followers', 'follower', 'follower.id = :userId', { userId })
+                .where('report.id = :reportId', { reportId })
+                .getCount();
+
+            return { isFollowing: count > 0 };
+        } catch (error) {
+            this.handleError(error, 'Failed to check follow status');
+        }
+    }
+
+    /**
+     * Retrieves the list of followers for a specific report by its ID.
+     *
+     * @param reportId - The unique identifier of the report whose followers are to be fetched.
+     * @returns A promise that resolves to a `ReportFollowersResponseDto` containing the names of the followers.
+     * @throws Will handle and rethrow errors if the report validation fails or if there is an issue fetching the followers.
+     */
+    async getReportFollowers(reportId: number): Promise<ReportFollowersResponseDto> {
+        try {
+            await this.validateReport(reportId);
+
+            const report = await this.reportRepository
+                .createQueryBuilder('report')
+                .leftJoinAndSelect('report.followers', 'follower')
+                .where('report.id = :reportId', { reportId })
+                .getOne();
+
+            return {
+                followers: report?.followers.map(follower => follower.name) || [],
+            };
+        } catch (error) {
+            this.handleError(error, 'Failed to get report followers');
+        }
+    }
+
+    /**
+     * Retrieves the list of report IDs that a specific user is following, along with the total count.
+     *
+     * @param userId - The unique identifier of the user whose followed reports are to be fetched.
+     * @returns A promise that resolves to an object containing an array of report IDs and the total number of followed reports.
+     * @throws Will handle and rethrow errors encountered during user validation or database queries.
+     */
+    async getUserFollowedReports(userId: number): Promise<UserFollowedReportsResponseDto> {
+        try {
+            await this.validateUser(userId);
+
+            const [reports, total] = await this.reportRepository
+                .createQueryBuilder('report')
+                .innerJoin('report.followers', 'follower', 'follower.id = :userId', { userId })
+                .select(['report.id'])
+                .getManyAndCount();
+
+            return {
+                reports: reports.map(report => report.id),
+                total,
+            };
+        } catch (error) {
+            this.handleError(error, 'Failed to get user followed reports');
+        }
+    }
+
+    /**
+     * Retrieves the IDs of all followers for a given report.
+     *
+     * @param reportId - The unique identifier of the report whose followers' IDs are to be fetched.
+     * @returns A promise that resolves to a `ReportFollowersIdsResponseDto` containing an array of follower IDs.
+     * @throws Will handle and rethrow errors if the report validation fails or if there is an issue fetching the followers.
+     */
+    async getFollowersIds(reportId: number): Promise<ReportFollowersIdsResponseDto> {
+        try {
+            await this.validateReport(reportId);
+
+            const report = await this.reportRepository
+                .createQueryBuilder('report')
+                .leftJoinAndSelect('report.followers', 'follower')
+                .where('report.id = :reportId', { reportId })
+                .getOne();
+
+            return {
+                followers: report?.followers.map(follower => follower.id) || [],
+            };
+        } catch (error) {
+            this.handleError(error, 'Failed to get followers IDs');
+        }
+    }
+
+    /**
+     * Validates the existence of a user by their ID.
+     *
+     * @param userId - The unique identifier of the user to validate.
+     * @returns A promise that resolves to the found {@link User} entity.
+     * @throws {BadRequestException} If the userId is not provided.
+     * @throws {NotFoundException} If no user is found with the given ID.
+     */
+    private async validateUser(userId: number): Promise<User> {
+        if (!userId) {
+            throw new BadRequestException('User ID is required');
+        }
+
+        const user = await this.userRepository.findOne({ where: { id: Equal(userId) } });
+        if (!user) {
+            throw new NotFoundException(`User with ID ${userId} not found`);
+        }
+
+        return user;
+    }
+
+    /**
+     * Validates the existence of a report by its ID.
+     *
+     * @param reportId - The unique identifier of the report to validate.
+     * @returns A promise that resolves to the found {@link Report} entity.
+     * @throws {BadRequestException} If the report ID is not provided.
+     * @throws {NotFoundException} If no report is found with the given ID.
+     */
+    private async validateReport(reportId: number): Promise<Report> {
+        if (!reportId) {
+            throw new BadRequestException('Report ID is required');
+        }
+
+        const report = await this.reportRepository.findOne({ where: { id: Equal(reportId) } });
+        if (!report) {
+            throw new NotFoundException(`Report with ID ${reportId} not found`);
+        }
+
+        return report;
+    }
+
+    /**
+     * Validates the existence of a user and a report by their respective IDs.
+     *
+     * @param userId - The unique identifier of the user to validate.
+     * @param reportId - The unique identifier of the report to validate.
+     * @returns A promise that resolves to an object containing the validated user and report.
+     * @throws Will throw an error if either the user or the report does not exist or fails validation.
+     */
+    private async validateUserAndReport(
+        userId: number,
+        reportId: number,
+    ): Promise<{ user: User; report: Report }> {
+        const [user, report] = await Promise.all([
+            this.validateUser(userId),
+            this.validateReport(reportId),
+        ]);
+
+        return { user, report };
+    }
+
+    /**
+     * Handles errors by rethrowing specific known exceptions or throwing a generic BadRequestException.
+     *
+     * @param error - The error object to handle.
+     * @param defaultMessage - The default error message to use if the error is not a known exception.
+     * @throws NotFoundException | ConflictException | BadRequestException - Rethrows if the error is one of these types.
+     * @throws BadRequestException - Throws with the provided default message if the error is not a known exception.
+     */
+    private handleError(error: unknown, defaultMessage: string): never {
+        if (
+            error instanceof NotFoundException ||
+            error instanceof ConflictException ||
+            error instanceof BadRequestException
+        ) {
+            throw error;
+        }
+        throw new BadRequestException(defaultMessage);
+    }
+}

--- a/backend/src/modules/reports/reports.module.ts
+++ b/backend/src/modules/reports/reports.module.ts
@@ -4,11 +4,12 @@ import { Report } from 'src/database/entities/report.entity';
 import { UploadModule } from '../upload/upload.module';
 import { CommentsModule } from './comments/comments.module';
 import { ReportsController } from './controllers/reports.controller';
+import { FollowsModule } from './follows/follows.module';
 import { REPORTS_SERVICE } from './interfaces/reports-service.interface';
 import { ReportsService } from './services/reports.service';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Report]), UploadModule, CommentsModule],
+    imports: [TypeOrmModule.forFeature([Report]), UploadModule, CommentsModule, FollowsModule],
     controllers: [ReportsController],
     providers: [
         {

--- a/backend/src/modules/users/controllers/user-follows.controller.ts
+++ b/backend/src/modules/users/controllers/user-follows.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Inject, Param, ParseIntPipe, Req } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { UserFollowedReportsResponseDto } from '../../reports/follows/dto';
+import {
+    FOLLOWS_SERVICE,
+    IFollowsService,
+} from '../../reports/follows/interfaces/follows-service.interface';
+
+@ApiTags('User Follows')
+@Controller({
+    path: 'users',
+    version: '1',
+})
+export class UserFollowsController {
+    constructor(
+        @Inject(FOLLOWS_SERVICE)
+        private readonly followsService: IFollowsService,
+    ) {}
+
+    @Get('me/followed-reports')
+    @ApiOperation({ summary: 'Get reports followed by the current user' })
+    @ApiResponse({
+        status: 200,
+        description: 'List of reports followed by the user',
+        type: UserFollowedReportsResponseDto,
+    })
+    @ApiResponse({ status: 404, description: 'User not found' })
+    async getCurrentUserFollowedReports(@Req() req): Promise<UserFollowedReportsResponseDto> {
+        const userId = req.user.id;
+        return await this.followsService.getUserFollowedReports(userId);
+    }
+
+    @Get(':userId/followed-reports')
+    @ApiOperation({ summary: 'Get reports followed by a specific user' })
+    @ApiParam({ name: 'userId', description: 'ID of the user', type: 'number' })
+    @ApiResponse({
+        status: 200,
+        description: 'List of reports followed by the user',
+        type: UserFollowedReportsResponseDto,
+    })
+    @ApiResponse({ status: 400, description: 'Invalid request parameters' })
+    @ApiResponse({ status: 404, description: 'User not found' })
+    async getUserFollowedReports(
+        @Param('userId', ParseIntPipe) userId: number,
+    ): Promise<UserFollowedReportsResponseDto> {
+        return await this.followsService.getUserFollowedReports(userId);
+    }
+}

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/database/entities/user.entity';
+import { FollowsModule } from '../reports/follows/follows.module';
+import { UserFollowsController } from './controllers/user-follows.controller';
 import { UsersController } from './controllers/users.controller';
 import { USER_SERVICE } from './interfaces/user-service.interface';
 import { UsersService } from './services/users.service';
@@ -35,9 +37,9 @@ import { UsersService } from './services/users.service';
  * @since 1.0.0
  */
 @Module({
-    imports: [TypeOrmModule.forFeature([User])],
+    imports: [TypeOrmModule.forFeature([User]), FollowsModule],
     exports: [TypeOrmModule, USER_SERVICE],
-    controllers: [UsersController],
+    controllers: [UsersController, UserFollowsController],
     providers: [
         {
             provide: USER_SERVICE,


### PR DESCRIPTION
This pull request introduces a new feature to manage follow relationships between users and reports in the backend. It includes the addition of a `FollowsModule`, a controller to handle HTTP requests, DTOs for structured responses, and an interface for the service layer. The most important changes are detailed below.

### Feature Implementation: Follow Management

#### Controller and Endpoints
* Added `FollowsController` to handle operations such as following/unfollowing reports, retrieving followers' names/IDs, and checking follow status. It includes detailed Swagger annotations for API documentation.

#### DTOs for API Responses
* Created `FollowActionResponseDto` to encapsulate the result of follow/unfollow actions.
* Created `FollowStatusResponseDto` to indicate whether a user is following a report.
* Created `ReportFollowersResponseDto` to return follower names for a report.
* Created `ReportFollowersIdsResponseDto` to return follower IDs for a report.
* Created `UserFollowedReportsResponseDto` to return reports followed by a user and the total count.

#### Module and Service Layer
* Added `FollowsModule`, which integrates the `FollowsController`, `FollowsService`, and TypeORM entities (`User` and `Report`) for database interaction.
* Defined the `IFollowsService` interface to outline the contract for follow-related operations, including methods for following/unfollowing reports, checking follow status, and retrieving followers.